### PR TITLE
Have x64-core export CryptoJS

### DIFF
--- a/builder/build.yml
+++ b/builder/build.yml
@@ -116,6 +116,7 @@ exports:
     rabbit-legacy: CryptoJS.RabbitLegacy
 
     core: CryptoJS
+    x64-core: CryptoJS
 
     evpkdf: CryptoJS.EvpKDF
 


### PR DESCRIPTION
This changes x64-core to export CryptoJS (which it modifies).

Otherwise, `require('crypto-js/x64-core')` or anything that depends on x64-core such as `require('crypto-js/sha512')` crashes in Appcelerator Titanium.
