### PR TITLE
Bower support

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,28 @@
+# Contribution
+
+# Git Flow 
+
+The crypto-js project uses [git flow](https://github.com/nvie/gitflow) to manage branches. 
+Do your changes on the `develop` or even better on a `feature/*` branch. Don't do any changes on the `master` branch.
+
+# Pull request
+
+Target your pull request on `develop` branch. Other pull request won't be accepted.
+
+# How to build
+
+1. Clone
+
+2. Run
+
+    ```sh
+    npm install
+    ```
+
+3. Run
+
+    ```sh
+    npm run build
+    ```
+    
+4. Check `build` folder

--- a/README.md
+++ b/README.md
@@ -5,8 +5,9 @@ Modularized port of googlecode project crypto-js.
 ## Node.js (Install)
 
 Requirements:
-* Node.js
-* npm (Node.js package manager)
+
+- Node.js
+- npm (Node.js package manager)
 
 ```bash
 npm install crypto-js
@@ -15,6 +16,7 @@ npm install crypto-js
 ### Usage
 
 Modular include:
+
 ```javascript
 var AES = require("crypto-js/aes");
 var SHA256 = require("crypto-js/sha256");
@@ -23,6 +25,7 @@ console.log(SHA256("Message"));
 ```
 
 Including all libraries, for access to extra methods:
+
 ```javascript
 var CryptoJS = require("crypto-js");
 console.log(CryptoJS.HmacSHA1("Message", "Key"));
@@ -30,21 +33,58 @@ console.log(CryptoJS.HmacSHA1("Message", "Key"));
 
 ## Client (browser)
 
+Requirements:
+
+- Node.js
+- Bower (package manager for frontend)
+
+```bash
+bower install crypto-js
+```
+
 ### Usage
 
 Modular include:
+
 ```javascript
+require.config({
+    packages: [
+        {
+            name: 'crypto-js',
+            location: 'path-to/bower_components/crypto-js',
+            main: 'index'
+        }
+    ]
+});
+
 require(["crypto-js/aes", "crypto-js/sha256"], function (AES, SHA256) {
     console.log(SHA256("Message"));
 });
 ```
 
 Including all libraries, for access to extra methods:
+
 ```javascript
-require("crypto-js", function (CryptoJS) {
+// Above-mentioned will work or use this simple form
+require.config({
+    paths: {
+        'require-js': 'path-to/bower_components/crypto-js/crypto-js'
+    }
+});
+
+require(["crypto-js"], function (CryptoJS) {
     console.log(CryptoJS.HmacSHA1("Message", "Key"));
 });
 ```
+
+### Usage without RequireJS
+
+```html
+<script type="text/javascript" src="path-to/bower_components/crypto-js/crypto-js.js"></script>
+<script type="text/javascript">
+    var encrypted = CryptoJS.AES(...);
+    var encrypted = CryptoJS.SHA256(...);
+</script>
 
 ## API
 
@@ -121,17 +161,6 @@ See: https://code.google.com/p/crypto-js
 - ```crypto-js/pad-iso97971```
 - ```crypto-js/pad-zeropadding```
 - ```crypto-js/pad-nopadding```
-
-## Contribution
-
-### Git Flow 
-
-The crypto-js project uses [git flow](https://github.com/nvie/gitflow) to manage branches. 
-Do your changes on the `develop` or even better on a `feature/*` branch. Don't do any changes on the `master` branch.
-
-### Pull request
-
-Target your pull request on `develop` branch. Other pull request won't be accepted.
 
 ## License
 

--- a/package.json
+++ b/package.json
@@ -21,6 +21,10 @@
       "url": "http://opensource.org/licenses/MIT"
     }
   ],
+  "scripts": {
+    "build": "grunt build",
+    "check": "grunt default"
+  },
   "main": "index.js",
   "dependencies": {},
   "devDependencies": {


### PR DESCRIPTION
- Added bower.json file
- Added .npmignore for easier NPM publish, it will prevent unneeded files to sneak in NPM installations
- Modified package.json file (bumped version, added reference to build script, see new `README.md` section)
- Commented out cleanup after build procedure (files are needed for Bower and NPM)

Unfortunately, NPM publish directly from repository is not yet possible:

``` js
require('crypto-js/build/crypto-js/lib-uncompressed/aes')
```

is very ugly and I don't want to break backward compatibility with existing installations. So far I haven't found a way to explain NPM/Node to look for `crypto-js/whatever` not in root folder of package, but somewhere else.

So for now NPM publish procedure will stay the same, unless I'll find a way to leave files in sub-folders and refer to them as before. Bower requires only pre-build and can be published without extra efforts.

In order to register Bower package please do:

``` sh
bower register crypto-js git://github.com/evanvosberg/crypto-js.git
```

So far package name `crypto-js` is not taken yet, so be quick :)

What could be done after this is to make the following structure (I can't make builder to produce this kind of output):
- crypto-js
- build
  - components
  - rollupds
- lib **note that this folder will now contain uncompressed files**
  - ...nodejs/amd stuff, point `package.json`'s `main` property to index file there
- lib-compressed
  - ...nodejs/amd stuff
- src
  - ...raw files

This will require users of previous NPM package to update their references from `require('crypto-js/whatever')` to `require('crypto-js/lib/whatever')` but it seems that this is a wide-spread practice to put stuff into `lib`.
