### PR TITLE
Fix for the HMAC-SHA224 and HMAC-SHA384 functions

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -210,14 +210,11 @@ var CryptoJS = CryptoJS || (function (Math, undefined) {
                     var thatByte = (thatWords[i >>> 2] >>> (24 - (i % 4) * 8)) & 0xff;
                     thisWords[(thisSigBytes + i) >>> 2] |= thatByte << (24 - ((thisSigBytes + i) % 4) * 8);
                 }
-            } else if (thatWords.length > 0xffff) {
+            } else {
                 // Copy one word at a time
                 for (var i = 0; i < thatSigBytes; i += 4) {
                     thisWords[(thisSigBytes + i) >>> 2] = thatWords[i >>> 2];
                 }
-            } else {
-                // Copy all words at once
-                thisWords.push.apply(thisWords, thatWords);
             }
             this.sigBytes += thatSigBytes;
 

--- a/test/hmac-md5-profile.js
+++ b/test/hmac-md5-profile.js
@@ -1,8 +1,8 @@
-YUI.add('algo-hmac-profile', function (Y) {
+YUI.add('algo-hmac-md5-profile', function (Y) {
     var C = CryptoJS;
 
     Y.Profiler.add({
-        name: 'HMAC',
+        name: 'HMAC MD5',
 
         setUp: function () {
             this.data = {

--- a/test/hmac-md5-test.js
+++ b/test/hmac-md5-test.js
@@ -1,8 +1,8 @@
-YUI.add('algo-hmac-test', function (Y) {
+YUI.add('algo-hmac-md5-test', function (Y) {
     var C = CryptoJS;
 
     Y.Test.Runner.add(new Y.Test.Case({
-        name: 'HMAC',
+        name: 'HMAC MD5',
 
         testVector1: function () {
             Y.Assert.areEqual('9294727a3638bb1c13f48ef8158bfc9d', C.HmacMD5('Hi There', C.enc.Hex.parse('0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b')).toString());
@@ -14,6 +14,14 @@ YUI.add('algo-hmac-test', function (Y) {
 
         testVector3: function () {
             Y.Assert.areEqual('56be34521d144c88dbb8c733f0e8b3f6', C.HmacMD5(C.enc.Hex.parse('dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd'), C.enc.Hex.parse('aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa')).toString());
+        },
+
+        testVector4: function () {
+            Y.Assert.areEqual('7ee2a3cc979ab19865704644ce13355c', C.HmacMD5('ABCDEFGHIJKLMNOPQRSTUVWXYZ', 'A'));
+        },
+
+        testVector5: function () {
+            Y.Assert.areEqual('0e1bd89c43e3e6e3b3f8cf1d5ba4f77a', C.HmacMD5('abcdefghijklmnopqrstuvwxyz', 'A'));
         },
 
         testUpdate: function () {

--- a/test/hmac-sha224-test.js
+++ b/test/hmac-sha224-test.js
@@ -1,0 +1,59 @@
+YUI.add('algo-hmac-sha224-test', function (Y) {
+    var C = CryptoJS;
+
+    Y.Test.Runner.add(new Y.Test.Case({
+        name: 'HMAC SHA224',
+
+        testVector1: function () {
+            Y.Assert.areEqual('4e841ce7a4ae83fbcf71e3cd64bfbf277f73a14680aae8c518ac7861', C.HmacSHA224('Hi There', C.enc.Hex.parse('0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b')).toString());
+        },
+
+        testVector2: function () {
+            Y.Assert.areEqual('a30e01098bc6dbbf45690f3a7e9e6d0f8bbea2a39e6148008fd05e44', C.HmacSHA224('what do ya want for nothing?', 'Jefe').toString());
+        },
+
+        testVector3: function () {
+            Y.Assert.areEqual('cbff7c2716bbaa7c77bed4f491d3e8456cb6c574e92f672b291acf5b', C.HmacSHA224(C.enc.Hex.parse('dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd'), C.enc.Hex.parse('aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa')).toString());
+        },
+
+        testVector4: function () {
+            Y.Assert.areEqual('61bf669da4fdcd8e5c3bd09ebbb4a986d3d1b298d3ca05c511f7aeff', C.HmacSHA224('ABCDEFGHIJKLMNOPQRSTUVWXYZ', 'A'));
+        },
+
+        testVector5: function () {
+            Y.Assert.areEqual('16fc69ada3c3edc1fe9144d6b98d93393833ae442bedf681110a1176', C.HmacSHA224('abcdefghijklmnopqrstuvwxyz', 'A'));
+        },
+
+        testUpdate: function () {
+            var hmac = C.algo.HMAC.create(C.algo.SHA224, C.enc.Hex.parse('aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'));
+            hmac.update(C.enc.Hex.parse('dddddddddddddddddddddddddddddddddddd'));
+            hmac.update(C.enc.Hex.parse('dddddddddddddddddddddddddddddddd'));
+            hmac.update(C.enc.Hex.parse('dddddddddddddddddddddddddddddddd'));
+
+            Y.Assert.areEqual(C.HmacSHA224(C.enc.Hex.parse('dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd'), C.enc.Hex.parse('aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa')).toString(), hmac.finalize().toString());
+        },
+
+        testInputIntegrity: function () {
+            var message = C.lib.WordArray.create([0x12345678]);
+            var key = C.lib.WordArray.create([0x12345678]);
+
+            var expectedMessage = message.toString();
+            var expectedKey = key.toString();
+
+            C.HmacSHA224(message, key);
+
+            Y.Assert.areEqual(expectedMessage, message.toString());
+            Y.Assert.areEqual(expectedKey, key.toString());
+        },
+
+        testRespectKeySigBytes: function () {
+            var key = C.lib.WordArray.random(8);
+            key.sigBytes = 4;
+
+            var keyClamped = key.clone();
+            keyClamped.clamp();
+
+            Y.Assert.areEqual(CryptoJS.HmacSHA224("Message", keyClamped).toString(), CryptoJS.HmacSHA224("Message", key).toString());
+        }
+    }));
+}, '$Rev$');

--- a/test/hmac-sha256-test.js
+++ b/test/hmac-sha256-test.js
@@ -1,0 +1,59 @@
+YUI.add('algo-hmac-sha256-test', function (Y) {
+    var C = CryptoJS;
+
+    Y.Test.Runner.add(new Y.Test.Case({
+        name: 'HMAC SHA256',
+
+        testVector1: function () {
+            Y.Assert.areEqual('492ce020fe2534a5789dc3848806c78f4f6711397f08e7e7a12ca5a4483c8aa6', C.HmacSHA256('Hi There', C.enc.Hex.parse('0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b')).toString());
+        },
+
+        testVector2: function () {
+            Y.Assert.areEqual('5bdcc146bf60754e6a042426089575c75a003f089d2739839dec58b964ec3843', C.HmacSHA256('what do ya want for nothing?', 'Jefe').toString());
+        },
+
+        testVector3: function () {
+            Y.Assert.areEqual('7dda3cc169743a6484649f94f0eda0f9f2ff496a9733fb796ed5adb40a44c3c1', C.HmacSHA256(C.enc.Hex.parse('dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd'), C.enc.Hex.parse('aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa')).toString());
+        },
+
+        testVector4: function () {
+            Y.Assert.areEqual('a89dc8178c1184a62df87adaa77bf86e93064863d93c5131140b0ae98b866687', C.HmacSHA256('ABCDEFGHIJKLMNOPQRSTUVWXYZ', 'A'));
+        },
+
+        testVector5: function () {
+            Y.Assert.areEqual('d8cb78419c02fe20b90f8b77427dd9f81817a751d74c2e484e0ac5fc4e6ca986', C.HmacSHA256('abcdefghijklmnopqrstuvwxyz', 'A'));
+        },
+
+        testUpdate: function () {
+            var hmac = C.algo.HMAC.create(C.algo.SHA256, C.enc.Hex.parse('aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'));
+            hmac.update(C.enc.Hex.parse('dddddddddddddddddddddddddddddddddddd'));
+            hmac.update(C.enc.Hex.parse('dddddddddddddddddddddddddddddddd'));
+            hmac.update(C.enc.Hex.parse('dddddddddddddddddddddddddddddddd'));
+
+            Y.Assert.areEqual(C.HmacSHA256(C.enc.Hex.parse('dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd'), C.enc.Hex.parse('aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa')).toString(), hmac.finalize().toString());
+        },
+
+        testInputIntegrity: function () {
+            var message = C.lib.WordArray.create([0x12345678]);
+            var key = C.lib.WordArray.create([0x12345678]);
+
+            var expectedMessage = message.toString();
+            var expectedKey = key.toString();
+
+            C.HmacSHA256(message, key);
+
+            Y.Assert.areEqual(expectedMessage, message.toString());
+            Y.Assert.areEqual(expectedKey, key.toString());
+        },
+
+        testRespectKeySigBytes: function () {
+            var key = C.lib.WordArray.random(8);
+            key.sigBytes = 4;
+
+            var keyClamped = key.clone();
+            keyClamped.clamp();
+
+            Y.Assert.areEqual(CryptoJS.HmacSHA256("Message", keyClamped).toString(), CryptoJS.HmacSHA256("Message", key).toString());
+        }
+    }));
+}, '$Rev$');

--- a/test/hmac-sha384-test.js
+++ b/test/hmac-sha384-test.js
@@ -1,0 +1,59 @@
+YUI.add('algo-hmac-sha384-test', function (Y) {
+    var C = CryptoJS;
+
+    Y.Test.Runner.add(new Y.Test.Case({
+        name: 'HMAC SHA384',
+
+        testVector1: function () {
+            Y.Assert.areEqual('7afaa633e20d379b02395915fbc385ff8dc27dcd3885e1068ab942eeab52ec1f20ad382a92370d8b2e0ac8b83c4d53bf', C.HmacSHA384('Hi There', C.enc.Hex.parse('0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b')).toString());
+        },
+
+        testVector2: function () {
+            Y.Assert.areEqual('af45d2e376484031617f78d2b58a6b1b9c7ef464f5a01b47e42ec3736322445e8e2240ca5e69e2c78b3239ecfab21649', C.HmacSHA384('what do ya want for nothing?', 'Jefe').toString());
+        },
+
+        testVector3: function () {
+            Y.Assert.areEqual('1383e82e28286b91f4cc7afbd13d5b5c6f887c05e7c4542484043a37a5fe45802a9470fb663bd7b6570fe2f503fc92f5', C.HmacSHA384(C.enc.Hex.parse('dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd'), C.enc.Hex.parse('aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa')).toString());
+        },
+
+        testVector4: function () {
+            Y.Assert.areEqual('365dfb271adb8e30fe6c74220b75df1b38c2d19b9d37f2e5a0ec2f3f22bd0406bf5b786e98d81b82c36d3d8a1be6cd07', C.HmacSHA384('ABCDEFGHIJKLMNOPQRSTUVWXYZ', 'A'));
+        },
+
+        testVector5: function () {
+            Y.Assert.areEqual('a8357d5e84da64140e41545562ae0782e2a58e39c6cd98939fad8d9080e774c84b7eaca4ba07f6dbf0f12eab912c5285', C.HmacSHA384('abcdefghijklmnopqrstuvwxyz', 'A'));
+        },
+
+        testUpdate: function () {
+            var hmac = C.algo.HMAC.create(C.algo.SHA384, C.enc.Hex.parse('aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'));
+            hmac.update(C.enc.Hex.parse('dddddddddddddddddddddddddddddddddddd'));
+            hmac.update(C.enc.Hex.parse('dddddddddddddddddddddddddddddddd'));
+            hmac.update(C.enc.Hex.parse('dddddddddddddddddddddddddddddddd'));
+
+            Y.Assert.areEqual(C.HmacSHA384(C.enc.Hex.parse('dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd'), C.enc.Hex.parse('aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa')).toString(), hmac.finalize().toString());
+        },
+
+        testInputIntegrity: function () {
+            var message = C.lib.WordArray.create([0x12345678]);
+            var key = C.lib.WordArray.create([0x12345678]);
+
+            var expectedMessage = message.toString();
+            var expectedKey = key.toString();
+
+            C.HmacSHA384(message, key);
+
+            Y.Assert.areEqual(expectedMessage, message.toString());
+            Y.Assert.areEqual(expectedKey, key.toString());
+        },
+
+        testRespectKeySigBytes: function () {
+            var key = C.lib.WordArray.random(8);
+            key.sigBytes = 4;
+
+            var keyClamped = key.clone();
+            keyClamped.clamp();
+
+            Y.Assert.areEqual(CryptoJS.HmacSHA384("Message", keyClamped).toString(), CryptoJS.HmacSHA384("Message", key).toString());
+        }
+    }));
+}, '$Rev$');

--- a/test/hmac-sha512-test.js
+++ b/test/hmac-sha512-test.js
@@ -1,0 +1,59 @@
+YUI.add('algo-hmac-sha512-test', function (Y) {
+    var C = CryptoJS;
+
+    Y.Test.Runner.add(new Y.Test.Case({
+        name: 'HMAC SHA512',
+
+        testVector1: function () {
+            Y.Assert.areEqual('7641c48a3b4aa8f887c07b3e83f96affb89c978fed8c96fcbbf4ad596eebfe496f9f16da6cd080ba393c6f365ad72b50d15c71bfb1d6b81f66a911786c6ce932', C.HmacSHA512('Hi There', C.enc.Hex.parse('0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b')).toString());
+        },
+
+        testVector2: function () {
+            Y.Assert.areEqual('164b7a7bfcf819e2e395fbe73b56e0a387bd64222e831fd610270cd7ea2505549758bf75c05a994a6d034f65f8f0e6fdcaeab1a34d4a6b4b636e070a38bce737', C.HmacSHA512('what do ya want for nothing?', 'Jefe').toString());
+        },
+
+        testVector3: function () {
+            Y.Assert.areEqual('ad9b5c7de72693737cd5e9d9f41170d18841fec1201c1c1b02e05cae116718009f771cad9946ddbf7e3cde3e818d9ae85d91b2badae94172d096a44a79c91e86', C.HmacSHA512(C.enc.Hex.parse('dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd'), C.enc.Hex.parse('aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa')).toString());
+        },
+
+        testVector4: function () {
+            Y.Assert.areEqual('a303979f7c94bb39a8ab6ce05cdbe28f0255da8bb305263e3478ef7e855f0242729bf1d2be55398f14da8e63f0302465a8a3f76c297bd584ad028d18ed7f0195', C.HmacSHA512('ABCDEFGHIJKLMNOPQRSTUVWXYZ', 'A'));
+        },
+
+        testVector5: function () {
+            Y.Assert.areEqual('8c2d56f7628325e62124c0a870ad98d101327fc42696899a06ce0d7121454022fae597e42c25ac3a4c380fd514f553702a5b0afaa9b5a22050902f024368e9d9', C.HmacSHA512('abcdefghijklmnopqrstuvwxyz', 'A'));
+        },
+
+        testUpdate: function () {
+            var hmac = C.algo.HMAC.create(C.algo.SHA512, C.enc.Hex.parse('aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'));
+            hmac.update(C.enc.Hex.parse('dddddddddddddddddddddddddddddddddddd'));
+            hmac.update(C.enc.Hex.parse('dddddddddddddddddddddddddddddddd'));
+            hmac.update(C.enc.Hex.parse('dddddddddddddddddddddddddddddddd'));
+
+            Y.Assert.areEqual(C.HmacSHA512(C.enc.Hex.parse('dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd'), C.enc.Hex.parse('aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa')).toString(), hmac.finalize().toString());
+        },
+
+        testInputIntegrity: function () {
+            var message = C.lib.WordArray.create([0x12345678]);
+            var key = C.lib.WordArray.create([0x12345678]);
+
+            var expectedMessage = message.toString();
+            var expectedKey = key.toString();
+
+            C.HmacSHA512(message, key);
+
+            Y.Assert.areEqual(expectedMessage, message.toString());
+            Y.Assert.areEqual(expectedKey, key.toString());
+        },
+
+        testRespectKeySigBytes: function () {
+            var key = C.lib.WordArray.random(8);
+            key.sigBytes = 4;
+
+            var keyClamped = key.clone();
+            keyClamped.clamp();
+
+            Y.Assert.areEqual(CryptoJS.HmacSHA512("Message", keyClamped).toString(), CryptoJS.HmacSHA512("Message", key).toString());
+        }
+    }));
+}, '$Rev$');

--- a/test/test.html
+++ b/test/test.html
@@ -1,4 +1,4 @@
-﻿<!doctype html>
+<!doctype html>
 <html>
     <head>
         <meta charset="utf-8">
@@ -59,7 +59,11 @@
         <script src="sha384-test.js"></script>
         <script src="sha3-test.js"></script>
         <script src="ripemd160-test.js"></script>
-        <script src="hmac-test.js"></script>
+        <script src="hmac-md5-test.js"></script>
+        <script src="hmac-sha224-test.js"></script>
+        <script src="hmac-sha256-test.js"></script>
+        <script src="hmac-sha384-test.js"></script>
+        <script src="hmac-sha512-test.js"></script>
         <script src="pbkdf2-test.js"></script>
         <script src="evpkdf-test.js"></script>
         <script src="mode-cbc-test.js"></script>


### PR DESCRIPTION
Expand the test coverage to check all of the SHA2 style HMAC routines and port a fix from the old Google code repo to fix failing HMAC-SHA224 and HMAC-SHA384.
