### PR TITLE
Fix caller for HmacSHA3 (v3.1.5)

### DIFF
--- a/hmac-sha3.js
+++ b/hmac-sha3.js
@@ -13,6 +13,6 @@
 	}
 }(this, function (CryptoJS) {
 
-	return CryptoJSHmacSHA3;
+	return CryptoJS.HmacSHA3;
 
 }));


### PR DESCRIPTION
Hi, I just want to let you know a typo in hmac-sha3.js (at master branch), which causes a ReferenceError when calling `require('crypto-js/hmac-sha3')`.

The error message in browser is like:

```
Uncaught ReferenceError: CryptoJSHmacSHA3 is not defined
```

I noticed you are currently working on `develop` branch, but still it is great if you would fix this issue and release v3.1.6.
