### PR TITLE
Putting (bits1 | bits2) expression into a variable

### DIFF
--- a/src/enc-base64.js
+++ b/src/enc-base64.js
@@ -90,7 +90,8 @@
                 if (i % 4) {
                     var bits1 = map.indexOf(base64Str.charAt(i - 1)) << ((i % 4) * 2);
                     var bits2 = map.indexOf(base64Str.charAt(i)) >>> (6 - (i % 4) * 2);
-                    words[nBytes >>> 2] |= (bits1 | bits2) << (24 - (nBytes % 4) * 8);
+                    var bitsCombined = bits1 | bits2;
+                    words[nBytes >>> 2] |= (bitsCombined) << (24 - (nBytes % 4) * 8);
                     nBytes++;
                 }
             }


### PR DESCRIPTION
Fixes iOS 6.x bug described here: https://code.google.com/p/crypto-js/issues/detail?id=80
