### PR TITLE
correct the package name in requirejs config function

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ Including all libraries, for access to extra methods:
 // Above-mentioned will work or use this simple form
 require.config({
     paths: {
-        'require-js': 'path-to/bower_components/crypto-js/crypto-js'
+        'crypto-js': 'path-to/bower_components/crypto-js/crypto-js'
     }
 });
 


### PR DESCRIPTION
hi, I found there is one  mistake about how to integrate with requirejs in the readme document .

the package name is wrong ,so I correct it to "crypto-js"

thank you. this is my first pull request in github. I hope it is right.
