### PR TITLE
Fix conflated prototype chains when extending.

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -48,7 +48,7 @@ var CryptoJS = CryptoJS || (function (Math, undefined) {
                 }
 
                 // Create default initializer
-                if (!subtype.hasOwnProperty('init')) {
+                if (!subtype.hasOwnProperty('init') || this.init === subtype.init) {
                     subtype.init = function () {
                         subtype.$super.init.apply(this, arguments);
                     };

--- a/test/lib-base-test.js
+++ b/test/lib-base-test.js
@@ -81,6 +81,12 @@ YUI.add('lib-base-test', function (Y) {
             this.data.obj.initArg = 'newValue';
 
             Y.Assert.areNotEqual(this.data.obj.initArg, this.data.objClone.initArg);
+        },
+
+        testCloneLeavesOriginalInitPrototypeUnchanged: function() {
+            Y.Assert.areEqual(this.data.obj, this.data.obj.init.prototype);
+            Y.Assert.areEqual(this.data.objClone, this.data.objClone.init.prototype);
+            Y.Assert.areNotEqual(this.data.obj.init.prototype, this.data.objClone.init.prototype);
         }
     }));
 }, '$Rev$');


### PR DESCRIPTION
This fixes a nasty bug in the `extend` method that under certain conditions will switch the parent object's prototype to be the derived child.  This happens if the parent object is also used as the `overrides`, which copies a reference to its `init` into the child, then overwrites the `init.prototype` for _both_ with the child.

This happens most commonly whenever you `clone` an object and has the consequence that every time you clone, the original object's prototype chain grows by one and gets applied to all the clones.  If you clone one object (say, a common baseline `WordArray`) a lot, you end up with with a prototype chain thousands of objects long, which completely kills performance in a very hard-to-debug way.

The fix is to check whether the child and parent share the same `init` function, and if so create a new one for the child so we can safely set its `prototype` without affecting the parent.  Test included.
