### PR TITLE
Use Object.create() instead of manipulating F.prototype.

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -16,8 +16,6 @@ var CryptoJS = CryptoJS || (function (Math, undefined) {
      * Base object for prototypal inheritance.
      */
     var Base = C_lib.Base = (function () {
-        function F() {}
-
         return {
             /**
              * Creates a new object that inherits from this object.
@@ -39,8 +37,7 @@ var CryptoJS = CryptoJS || (function (Math, undefined) {
              */
             extend: function (overrides) {
                 // Spawn
-                F.prototype = this;
-                var subtype = new F();
+                var subtype = Object.create(this);
 
                 // Augment
                 if (overrides) {


### PR DESCRIPTION
This makes a big improvement to performance throughout, since so many operations pass through `extend` and JITs get upset when a prototype is repeatedly (re)set.

The caveat is that `Object.create` is not supported in IE8 and earlier.  I didn't see any formal statement of what browsers `crypto-js` aims to be compatible with so hopefully that's all right.

(@evanvosberg, I needed to get the crypto running faster in my app, so I spent a solid day profiling and optimizing.  More PRs coming up.)

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/brix/crypto-js/68)

<!-- Reviewable:end -->
