### PR TITLE
On BlockCipher reset, don't recreate _mode, just re-init.

### DIFF
--- a/src/cipher-core.js
+++ b/src/cipher-core.js
@@ -451,11 +451,15 @@ CryptoJS.lib.Cipher || (function (undefined) {
                 var modeCreator = mode.createEncryptor;
             } else /* if (this._xformMode == this._DEC_XFORM_MODE) */ {
                 var modeCreator = mode.createDecryptor;
-
                 // Keep at least one block in the buffer for unpadding
                 this._minBufferSize = 1;
             }
-            this._mode = modeCreator.call(mode, this, iv && iv.words);
+            if (this._mode && this._modeCreator == modeCreator) {
+                this._mode.init(this, iv && iv.words);
+            } else {
+                this._mode = modeCreator.call(mode, this, iv && iv.words);
+                this._modeCreator = modeCreator;
+            }
         },
 
         _doProcessBlock: function (words, offset) {


### PR DESCRIPTION
Crypto functions that need to reset their cipher a lot (such as CMAC) waste a lot of time repeatedly re-creating the encryptor/decryptor.  While not exactly equivalent, re-initing the existing encryptor/decryptor turns out to be sufficient, thanks to the way modes are written to ignore any previous block information if the IV is set.

This change _might_ break custom block cipher modes, but it seems unlikely and would be easy to fix, so IMHO the performance improvement is worth it.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/brix/crypto-js/69)

<!-- Reviewable:end -->
