### PR TITLE
fixed infinite loop bug in zero padding unpad

### DIFF
--- a/src/pad-zeropadding.js
+++ b/src/pad-zeropadding.js
@@ -17,9 +17,11 @@ CryptoJS.pad.ZeroPadding = {
 
         // Unpad
         var i = data.sigBytes - 1;
-        while (!((dataWords[i >>> 2] >>> (24 - (i % 4) * 8)) & 0xff)) {
-            i--;
+        for (var i = data.sigBytes - 1; i >= 0; i--) {
+            if (((dataWords[i >>> 2] >>> (24 - (i % 4) * 8)) & 0xff)) {
+                data.sigBytes = i + 1;
+                break;
+            }
         }
-        data.sigBytes = i + 1;
     }
 };


### PR DESCRIPTION
Hi, I am using crypto-js for a password manager app. Sometimes it happens that the while loop in the zero padding unpad is running forever and crashes the application. I created a fix for it. It works just fine for me and I wanted to share it with you.