### PR TITLE
Putting (bits1 | bits2) expression into a variable (fix for iOS 6 bug)

### DIFF
--- a/src/enc-base64.js
+++ b/src/enc-base64.js
@@ -106,7 +106,8 @@
           if (i % 4) {
               var bits1 = reverseMap[base64Str.charCodeAt(i - 1)] << ((i % 4) * 2);
               var bits2 = reverseMap[base64Str.charCodeAt(i)] >>> (6 - (i % 4) * 2);
-              words[nBytes >>> 2] |= (bits1 | bits2) << (24 - (nBytes % 4) * 8);
+              var bitsCombined = bits1 | bits2;
+              words[nBytes >>> 2] |= bitsCombined << (24 - (nBytes % 4) * 8);
               nBytes++;
           }
       }


### PR DESCRIPTION
Previously fixed here:
https://github.com/brix/crypto-js/pull/40

More info:
https://github.com/Runscope/crypto-js/issues/80