### PR TITLE
Typo in AES Encryption Plain encryption example

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ See: https://code.google.com/p/crypto-js
 var CryptoJS = require("crypto-js");
 
 // Encrypt
-var cipherText = CryptoJS.AES.encrypt('my message', 'secret key 123').toString();
+var ciphertext = CryptoJS.AES.encrypt('my message', 'secret key 123').toString();
 
 // Decrypt
 var bytes  = CryptoJS.AES.decrypt(ciphertext, 'secret key 123');


### PR DESCRIPTION
Changed the var name from `cipherText` to lowercase `ciphertext` so the "AES Encryption >  Plain encryption" example works.