### PR TITLE
add grunt-cli to devDepencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
   "devDependencies": {
     "fmd": "~0.0.3",
     "grunt": "^0.4.5",
+    "grunt-cli": "^1.3.2",
     "grunt-contrib-clean": "^0.6.0",
     "grunt-contrib-copy": "^0.6.0",
     "grunt-contrib-jshint": "^0.10.0",


### PR DESCRIPTION
Add `grunt-cli` to devDependencies. Right now you have to install it globally before `npm run build`.