### PR TITLE
Supports encoding and decoding of java-encoded base64 safe url characters

### DIFF
--- a/src/enc-base64.js
+++ b/src/enc-base64.js
@@ -13,6 +13,8 @@
          * Converts a word array to a Base64 string.
          *
          * @param {WordArray} wordArray The word array.
+         * 
+         * @param {boolean} urlSafe Whether to use safe url.
          *
          * @return {string} The Base64 string.
          *
@@ -60,6 +62,8 @@
          * Converts a Base64 string to a word array.
          *
          * @param {string} base64Str The Base64 string.
+         * 
+         * @param {boolean} urlSafe Whether to use safe url.
          *
          * @return {WordArray} The word array.
          *

--- a/src/enc-base64.js
+++ b/src/enc-base64.js
@@ -22,11 +22,11 @@
          *
          *     var base64String = CryptoJS.enc.Base64.stringify(wordArray);
          */
-        stringify: function (wordArray) {
+        stringify: function (wordArray, urlSafe=false) {
             // Shortcuts
             var words = wordArray.words;
             var sigBytes = wordArray.sigBytes;
-            var map = this._map;
+            var map = urlSafe ? this._safe_map : this._map;
 
             // Clamp excess bits
             wordArray.clamp();
@@ -69,10 +69,10 @@
          *
          *     var wordArray = CryptoJS.enc.Base64.parse(base64String);
          */
-        parse: function (base64Str) {
+        parse: function (base64Str, urlSafe=false) {
             // Shortcuts
             var base64StrLength = base64Str.length;
-            var map = this._map;
+            var map = urlSafe ? this._safe_map : this._map;
             var reverseMap = this._reverseMap;
 
             if (!reverseMap) {
@@ -96,7 +96,8 @@
 
         },
 
-        _map: 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/='
+        _map: 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/=',
+        _safe_map: 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-_',
     };
 
     function parseLoop(base64Str, base64StrLength, reverseMap) {


### PR DESCRIPTION
Supports encoding and decoding of java-encoded base64 safe url characters
org.apache.commons.codec.binary.Base64.encodeBase64URLSafeString
example javaer output key='u-rXsDG_aegAnzC_CJt27plLGNqOfR****5o2ro1NOI';