### PR TITLE
Fix array length Allocation failed issue when Message is huge

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -411,7 +411,7 @@ var CryptoJS = CryptoJS || (function (Math, undefined) {
             var hexStrLength = hexStr.length;
 
             // Convert
-            var words = [];
+            var words = new Array((hexStrLength + 7) >>> 3);
             for (var i = 0; i < hexStrLength; i += 2) {
                 words[i >>> 3] |= parseInt(hexStr.substr(i, 2), 16) << (24 - (i % 8) * 4);
             }
@@ -470,7 +470,7 @@ var CryptoJS = CryptoJS || (function (Math, undefined) {
             var latin1StrLength = latin1Str.length;
 
             // Convert
-            var words = [];
+            var words = new Array((latin1StrLength + 3) >>> 2);
             for (var i = 0; i < latin1StrLength; i++) {
                 words[i >>> 2] |= (latin1Str.charCodeAt(i) & 0xff) << (24 - (i % 4) * 8);
             }
@@ -607,6 +607,10 @@ var CryptoJS = CryptoJS || (function (Math, undefined) {
 
             // Process blocks
             if (nWordsReady) {
+                if (dataWords.length < nWordsReady) {
+                    data.words = dataWords.concat(new Array(nWordsReady - dataWords.length));
+                    dataWords = data.words;
+                }
                 for (var offset = 0; offset < nWordsReady; offset += blockSize) {
                     // Perform concrete-algorithm logic
                     this._doProcessBlock(dataWords, offset);

--- a/src/core.js
+++ b/src/core.js
@@ -221,6 +221,11 @@ var CryptoJS = CryptoJS || (function (Math, undefined) {
             // Clamp excess bits
             this.clamp();
 
+            // Set array length first to fix array length allocation issue
+            if (thisWords.length < Math.ceil((thisSigBytes + thatSigBytes) / 4)) {
+                thisWords.length = Math.ceil((thisSigBytes + thatSigBytes) / 4);
+            }
+
             // Concat
             if (thisSigBytes % 4) {
                 // Copy one byte at a time

--- a/src/enc-base64.js
+++ b/src/enc-base64.js
@@ -100,7 +100,7 @@
     };
 
     function parseLoop(base64Str, base64StrLength, reverseMap) {
-      var words = [];
+      var words = new Array((base64StrLength - (base64StrLength >>> 2) + 2) >>> 2);
       var nBytes = 0;
       for (var i = 0; i < base64StrLength; i++) {
           if (i % 4) {

--- a/src/enc-utf16.js
+++ b/src/enc-utf16.js
@@ -114,7 +114,7 @@
             var utf16StrLength = utf16Str.length;
 
             // Convert
-            var words = [];
+            var words = new Array((utf16StrLength + 1) >>> 1);
             for (var i = 0; i < utf16StrLength; i++) {
                 words[i >>> 1] |= swapEndian(utf16Str.charCodeAt(i) << (16 - (i % 2) * 16));
             }

--- a/src/md5.js
+++ b/src/md5.js
@@ -150,6 +150,12 @@
             var nBitsTotal = this._nDataBytes * 8;
             var nBitsLeft = data.sigBytes * 8;
 
+            var newLength = Math.max((nBitsLeft >>> 5) + 1, (((nBitsLeft + 64) >>> 9) << 4) + 16);
+            if (dataWords.length < newLength) {
+                data.words = dataWords.concat(new Array(newLength - dataWords.length));
+                dataWords = data.words;
+            }
+
             // Add padding
             dataWords[nBitsLeft >>> 5] |= 0x80 << (24 - nBitsLeft % 32);
 

--- a/src/ripemd160.js
+++ b/src/ripemd160.js
@@ -148,6 +148,12 @@ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND 
             var nBitsTotal = this._nDataBytes * 8;
             var nBitsLeft = data.sigBytes * 8;
 
+            var newLength = Math.max((nBitsLeft >>> 5) + 1, (((nBitsLeft + 64) >>> 9) << 4) + 15);
+            if (dataWords.length < newLength) {
+                data.words = dataWords.concat(new Array(newLength - dataWords.length));
+                dataWords = data.words;
+            }
+
             // Add padding
             dataWords[nBitsLeft >>> 5] |= 0x80 << (24 - nBitsLeft % 32);
             dataWords[(((nBitsLeft + 64) >>> 9) << 4) + 14] = (

--- a/src/sha1.js
+++ b/src/sha1.js
@@ -75,6 +75,12 @@
             var nBitsTotal = this._nDataBytes * 8;
             var nBitsLeft = data.sigBytes * 8;
 
+            var newLength = Math.max((nBitsLeft >>> 5) + 1, (((nBitsLeft + 64) >>> 9) << 4) + 16);
+            if (dataWords.length < newLength) {
+                data.words = dataWords.concat(new Array(newLength - dataWords.length));
+                dataWords = data.words;
+            }
+
             // Add padding
             dataWords[nBitsLeft >>> 5] |= 0x80 << (24 - nBitsLeft % 32);
             dataWords[(((nBitsLeft + 64) >>> 9) << 4) + 14] = Math.floor(nBitsTotal / 0x100000000);

--- a/src/sha256.js
+++ b/src/sha256.js
@@ -124,6 +124,12 @@
             var nBitsTotal = this._nDataBytes * 8;
             var nBitsLeft = data.sigBytes * 8;
 
+            var newLength = Math.max((nBitsLeft >>> 5) + 1, (((nBitsLeft + 64) >>> 9) << 4) + 16);
+            if (dataWords.length < newLength) {
+                data.words = dataWords.concat(new Array(newLength - dataWords.length));
+                dataWords = data.words;
+            }
+
             // Add padding
             dataWords[nBitsLeft >>> 5] |= 0x80 << (24 - nBitsLeft % 32);
             dataWords[(((nBitsLeft + 64) >>> 9) << 4) + 14] = Math.floor(nBitsTotal / 0x100000000);

--- a/src/sha3.js
+++ b/src/sha3.js
@@ -220,6 +220,12 @@
             var nBitsLeft = data.sigBytes * 8;
             var blockSizeBits = this.blockSize * 32;
 
+            var newLength = Math.max((nBitsLeft >>> 5) + 1, (Math.ceil((nBitsLeft + 1) / blockSizeBits) * blockSizeBits) >>> 5);
+            if (dataWords.length < newLength) {
+                data.words = dataWords.concat(new Array(newLength - dataWords.length));
+                dataWords = data.words;
+            }
+
             // Add padding
             dataWords[nBitsLeft >>> 5] |= 0x1 << (24 - nBitsLeft % 32);
             dataWords[((Math.ceil((nBitsLeft + 1) / blockSizeBits) * blockSizeBits) >>> 5) - 1] |= 0x80;

--- a/src/sha512.js
+++ b/src/sha512.js
@@ -246,6 +246,12 @@
             var nBitsTotal = this._nDataBytes * 8;
             var nBitsLeft = data.sigBytes * 8;
 
+            var newLength = Math.max((nBitsLeft >>> 5) + 1, (((nBitsLeft + 128) >>> 10) << 5) + 32);
+            if (dataWords.length < newLength) {
+                data.words = dataWords.concat(new Array(newLength - dataWords.length));
+                dataWords = data.words;
+            }
+
             // Add padding
             dataWords[nBitsLeft >>> 5] |= 0x80 << (24 - nBitsLeft % 32);
             dataWords[(((nBitsLeft + 128) >>> 10) << 5) + 30] = Math.floor(nBitsTotal / 0x100000000);


### PR DESCRIPTION
When using crypto-js to encrypt and decrypt a file larger than 400MB, the program always crashes and says "FATAL ERROR: invalid array length Allocation failed - JavaScript heap out of memory".
After some research I found crypto-js directly access some array elements which have large index, which caused V8 engine to crash.
This answer https://stackoverflow.com/questions/55465821/55474570 is related.