### PR TITLE
Support self.crypto in Web Workers

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -12,6 +12,11 @@ var CryptoJS = CryptoJS || (function (Math, undefined) {
         crypto = window.crypto;
     }
 
+    // Native crypto in web worker (Browser)
+    if (typeof self !== 'undefined' && self.crypto) {
+        crypto = self.crypto;
+    }
+
     // Native (experimental IE 11) crypto from window (Browser)
     if (!crypto && typeof window !== 'undefined' && window.msCrypto) {
         crypto = window.msCrypto;


### PR DESCRIPTION
crypto-js fails to find a working crypto implementation when used in a web worker, because web workers have `self` instead of `window`.

I have verfied that my patch fixes the problem.