### PR TITLE
Throw type error if data is not string

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -550,8 +550,11 @@ var CryptoJS = CryptoJS || (function (Math, undefined) {
          */
         _append: function (data) {
             // Convert string to WordArray, else assume WordArray already
-            if (typeof data == 'string') {
+            var dataType = typeof data;
+            if (dataType == 'string') {
                 data = Utf8.parse(data);
+            } else {
+                throw new TypeError('The "data" argument must be string. Received type ' + dataType);
             }
 
             // Append


### PR DESCRIPTION
The result would be the same if data is not a string when we want to get a hashcode.

For example:

```javascript
const Crypto = require('crypto-js');

console.log(Crypto.MD5(1).toString()) // 487f7b22f68312d2c1bbc93b1aea445b
console.log(Crypto.MD5(2).toString()) // 487f7b22f68312d2c1bbc93b1aea445b
console.log(Crypto.MD5(3).toString()) // 487f7b22f68312d2c1bbc93b1aea445b
console.log(Crypto.MD5([32, 0, 0, 0]).toString()) // 487f7b22f68312d2c1bbc93b1aea445b
```
So, we should throw type error under these circumstances.


