### PR TITLE
Update Padding from 0x1 to 0x6 as in SHA3 standard

### DIFF
--- a/src/sha3.js
+++ b/src/sha3.js
@@ -221,7 +221,7 @@
             var blockSizeBits = this.blockSize * 32;
 
             // Add padding
-            dataWords[nBitsLeft >>> 5] |= 0x1 << (24 - nBitsLeft % 32);
+            dataWords[nBitsLeft >>> 5] |= 0x6 << (24 - nBitsLeft % 32);
             dataWords[((Math.ceil((nBitsLeft + 1) / blockSizeBits) * blockSizeBits) >>> 5) - 1] |= 0x80;
             data.sigBytes = dataWords.length * 4;
 


### PR DESCRIPTION
I observed CryptoJS SHA3 is different from PHP hash("sha3-512"). After comparing to code here: https://github.com/emn178/js-sha3 I found changing the 0x1 to 0x6 will make CryptoJS matching the standard SHA3 (at least for sha3-512)