### PR TITLE
avoid bundling node crypto in browser

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -35,7 +35,8 @@ var CryptoJS = CryptoJS || (function (Math, undefined) {
     // Native crypto import via require (NodeJS)
     if (!crypto && typeof require === 'function') {
         try {
-            crypto = require('crypto');
+            var pto = 'pto';
+            crypto = require('cry' + pto);
         } catch (err) {}
     }
 


### PR DESCRIPTION
Fixed #276 

I just follow the fix on the similar issue found in `decimal.js`.
https://github.com/MikeMcl/decimal.js/pull/42

However, crypto-js should probably consider removing `require` at all.
https://github.com/MikeMcl/decimal.js/pull/42#issuecomment-259472652