### PR TITLE
add browser field to avoid shimming crypto-browserify

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,6 +21,9 @@
     "test": "grunt default"
   },
   "main": "index.js",
+  "browser": {
+    "crypto": false
+  },
   "dependencies": {},
   "devDependencies": {
     "fmd": "~0.0.3",


### PR DESCRIPTION
based on spec https://github.com/defunctzombie/package-browser-field-spec

Adding this can help solve several issues related to webpack/nextjs build, as it avoids shimming the `crypto-browserify` when resolving `crypto-js/core`. Otherwise, user needs to manually update the resolving setting in their webpack/nextjs config.

related issues:
https://github.com/brix/crypto-js/issues/354
https://github.com/brix/crypto-js/issues/276
https://github.com/aws-amplify/amplify-js/issues/7570
