### PR TITLE
fix:The "cfg.salt" parameter don't work

### DIFF
--- a/src/cipher-core.js
+++ b/src/cipher-core.js
@@ -819,7 +819,7 @@ CryptoJS.lib.Cipher || (function (undefined) {
             cfg = this.cfg.extend(cfg);
 
             // Derive key and other params
-            var derivedParams = cfg.kdf.execute(password, cipher.keySize, cipher.ivSize);
+            var derivedParams = cfg.kdf.execute(password, cipher.keySize, cipher.ivSize, cfg.salt);
 
             // Add IV to config
             cfg.iv = derivedParams.iv;

--- a/test/config-test.js
+++ b/test/config-test.js
@@ -1,0 +1,26 @@
+YUI.add('config-test', function (Y) {
+    var C = CryptoJS;
+
+    Y.Test.Runner.add(new Y.Test.Case({
+        name: 'Config',
+
+        setUp: function () {
+            this.data = {
+                saltA: CryptoJS.enc.Hex.parse('AA00000000000000'),
+                saltB: CryptoJS.enc.Hex.parse('BB00000000000000')
+            };
+        },
+
+        testEncrypt: function () {
+            Y.Assert.areEqual(C.AES.encrypt('Test', 'Pass', { salt: this.data.saltA }).toString(), C.AES.encrypt('Test', 'Pass', { salt: this.data.saltA }).toString());
+            Y.Assert.areNotEqual(C.AES.encrypt('Test', 'Pass', { salt: this.data.saltA }).toString(), C.AES.encrypt('Test', 'Pass', { salt: this.data.saltB }).toString());
+        },
+
+        testDecrypt: function () {
+            var encryptedA = C.AES.encrypt('Test', 'Pass', { salt: this.data.saltA });
+            var encryptedB = C.AES.encrypt('Test', 'Pass', { salt: this.data.saltB });
+            Y.Assert.areEqual('Test', C.AES.decrypt(encryptedA, 'Pass').toString(C.enc.Utf8));
+            Y.Assert.areEqual('Test', C.AES.decrypt(encryptedB, 'Pass').toString(C.enc.Utf8));
+        }
+    }));
+}, '$Rev$');

--- a/test/test.html
+++ b/test/test.html
@@ -88,6 +88,7 @@
         <script src="aes-test.js"></script>
         <script src="des-test.js"></script>
         <script src="tripledes-test.js"></script>
+        <script src="config-test.js"></script>
 
         <!-- Test runner -->
         <script>


### PR DESCRIPTION
The "cfg.salt" parameter don't work when use the "password" of the string type.