### PR TITLE
Added a reminder about the AES decryption key to the README file.

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,11 @@ var CryptoJS = require("crypto-js");
 // Encrypt
 var ciphertext = CryptoJS.AES.encrypt('my message', 'secret key 123').toString();
 
+// Keep in mind that the object returned by CryptoJS.AES.encrypt includes the decryption key. If you intend to store the ciphertext, remove this beforehand:
+var encrypted = CryptoJS.AES.encrypt('my message', 'secret key 123');
+delete encrypted.key;
+var ciphertext = encrypted.toString();
+
 // Decrypt
 var bytes  = CryptoJS.AES.decrypt(ciphertext, 'secret key 123');
 var originalText = bytes.toString(CryptoJS.enc.Utf8);
@@ -129,6 +134,11 @@ var data = [{id: 1}, {id: 2}]
 
 // Encrypt
 var ciphertext = CryptoJS.AES.encrypt(JSON.stringify(data), 'secret key 123').toString();
+
+// Keep in mind that the object returned by CryptoJS.AES.encrypt includes the decryption key. If you intend to store the ciphertext, remove this beforehand:
+var encrypted = CryptoJS.AES.encrypt('my message', 'secret key 123');
+delete encrypted.key;
+var ciphertext = encrypted.toString();
 
 // Decrypt
 var bytes  = CryptoJS.AES.decrypt(ciphertext, 'secret key 123');


### PR DESCRIPTION
Currently, it's implied that you can simply call the CryptoJS.AES.encrypt method, and then turn it into a string and store the output. While the built-in .toString() outputs a salted version of the object, this could be misleading. The object that it returns includes the decryption key and depending on the implementation, it'd be easy for developers to unwittingly store the decryption key with the ciphertext, effectively rendering the encryption useless. It'd be useful to mention this information either in the README or somewhere else so that developers are aware of what the encrypt method outputs.