### PR TITLE
Added additional information regarding what the ciphertext output contains.

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ See: https://cryptojs.gitbook.io/docs/
 ```javascript
 var CryptoJS = require("crypto-js");
 
-// Encrypt
+// Encrypt - Note that CryptoJS.AES.encrypt returns an object that contains the decryption keys. The .toString() method of this library specifically ensures that the output is safe to be stored and cannot be decrypted. Storing the resulting object or encoding it isn't safe as it'd contain the decryption key.
 var ciphertext = CryptoJS.AES.encrypt('my message', 'secret key 123').toString();
 
 // Decrypt
@@ -127,7 +127,7 @@ var CryptoJS = require("crypto-js");
 
 var data = [{id: 1}, {id: 2}]
 
-// Encrypt
+// Encrypt - Note that CryptoJS.AES.encrypt returns an object that contains the decryption keys. The .toString() method of this library specifically ensures that the output is safe to be stored and cannot be decrypted. Storing the resulting object or encoding it isn't safe as it'd contain the decryption key.
 var ciphertext = CryptoJS.AES.encrypt(JSON.stringify(data), 'secret key 123').toString();
 
 // Decrypt


### PR DESCRIPTION
Currently, the documentation makes it seem like turning the output of CryptoJS.AES.encrypt() into a string is safe, but it doesn't clarify that the built-in .toString() method is special in that it concatenates a salt and the ciphertext, and doesn't include the decryption key with the output. If developers were to simply turn the output of the encrypt() method into a string without using said function, it would be trivial to decrypt the data. Not having this clarification in the documentation is potentially misleading and could lead to user data being stored insecurely. 