### PR TITLE
refactor: replace deprecated String.prototype.substr()

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -418,7 +418,7 @@ var CryptoJS = CryptoJS || (function (Math, undefined) {
             // Convert
             var words = [];
             for (var i = 0; i < hexStrLength; i += 2) {
-                words[i >>> 3] |= parseInt(hexStr.substr(i, 2), 16) << (24 - (i % 8) * 4);
+                words[i >>> 3] |= parseInt(hexStr.slice(i, i + 2), 16) << (24 - (i % 8) * 4);
             }
 
             return new WordArray.init(words, hexStrLength / 2);

--- a/test/rc4-test.js
+++ b/test/rc4-test.js
@@ -14,7 +14,7 @@ YUI.add('algo-rc4-test', function (Y) {
 
         testDrop: function () {
             Y.Assert.areEqual(
-                C.RC4.encrypt(C.enc.Hex.parse('00000000000000000000000000000000'), C.enc.Hex.parse('0123456789abcdef')).ciphertext.toString().substr(16),
+                C.RC4.encrypt(C.enc.Hex.parse('00000000000000000000000000000000'), C.enc.Hex.parse('0123456789abcdef')).ciphertext.toString().slice(16),
                 C.RC4Drop.encrypt(C.enc.Hex.parse('0000000000000000'), C.enc.Hex.parse('0123456789abcdef'), { drop: 2 }).ciphertext.toString()
             );
         },


### PR DESCRIPTION
[String.prototype.substr()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/substr) is deprecated so we replace it with [String.prototype.slice()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/slice) which works similarily but isn't deprecated.
.substr() probably isn't going away anytime soon but the change is trivial so it doesn't hurt to do it.