### PR TITLE
config default iv to fix aes error when key passed as wordarray and iv is not provided

### DIFF
--- a/src/cipher-core.js
+++ b/src/cipher-core.js
@@ -28,7 +28,7 @@ CryptoJS.lib.Cipher || (function (undefined) {
          *
          * @property {WordArray} iv The IV to use for this operation.
          */
-        cfg: Base.extend(),
+        cfg: Base.extend({iv: WordArray.create()}),
 
         /**
          * Creates this cipher in encryption mode.

--- a/test/aes-test.js
+++ b/test/aes-test.js
@@ -75,6 +75,11 @@ YUI.add('algo-aes-test', function (Y) {
 
             // Restore random method
             C.lib.WordArray.random = random;
-        }
+        },
+
+        testWithoutCfg: function () {
+            Y.Assert.areEqual('69c4e0d86a7b0430d8cdb78070b4c55a9e978e6d16b086570ef794ef97984232', C.AES.encrypt(C.enc.Hex.parse('00112233445566778899aabbccddeeff'), C.enc.Hex.parse('000102030405060708090a0b0c0d0e0f')).ciphertext.toString());
+            Y.Assert.areEqual('00112233445566778899aabbccddeeff', C.AES.decrypt(C.lib.CipherParams.create({ ciphertext: C.enc.Hex.parse('69c4e0d86a7b0430d8cdb78070b4c55a9e978e6d16b086570ef794ef97984232') }), C.enc.Hex.parse('000102030405060708090a0b0c0d0e0f')).toString());
+        },
     }));
 }, '$Rev$');


### PR DESCRIPTION
See also https://github.com/brix/crypto-js/issues/439#issuecomment-2172055554