### PR TITLE
fix jshint errors when run npm run test

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -1,4 +1,5 @@
 {
+  "esversion": 6,
   "bitwise": false, // Prohibits the use of bitwise operators (not confuse & with &&)
   "curly": true, // Requires to always put curly braces around blocks in loops and conditionals
   "eqeqeq": false, // Prohibits the use of == and != in favor of === and !==
@@ -28,6 +29,8 @@
     "Uint8ClampedArray": true,
     "ArrayBuffer": true,
     "Float32Array": true,
-    "Float64Array": true
+    "Float64Array": true,
+    "self": false,
+    "globalThis": false
   }
 }

--- a/src/cipher-core.js
+++ b/src/cipher-core.js
@@ -772,15 +772,16 @@ CryptoJS.lib.Cipher || (function (undefined) {
             }
 
             // Derive key and IV
+            let key;
             if (!hasher) {
-                var key = EvpKDF.create({ keySize: keySize + ivSize }).compute(password, salt);
+                key = EvpKDF.create({ keySize: keySize + ivSize }).compute(password, salt);
             } else {
-                var key = EvpKDF.create({ keySize: keySize + ivSize, hasher: hasher }).compute(password, salt);
+                key = EvpKDF.create({ keySize: keySize + ivSize, hasher: hasher }).compute(password, salt);
             }
             
 
             // Separate key and IV
-            var iv = WordArray.create(key.words.slice(keySize), ivSize * 4);
+            const iv = WordArray.create(key.words.slice(keySize), ivSize * 4);
             key.sigBytes = keySize * 4;
 
             // Return params


### PR DESCRIPTION
fix the following errors when execute `npm run test`.

```shell
@liudonghua123 ➜ /workspaces/crypto-js (fix_jshint) $ npm run test # need to add `"esversion": 6` to .jshintrc

> crypto-js@4.2.0 test
> grunt default

Running "jsonlint:all" (jsonlint) task
>> 1 file lint free.

Running "jshint:dev" (jshint) task

   src/blowfish.js
      8 |    const N = 16;
             ^ 'const' is available in ES6 (use 'esversion: 6') or Mozilla JS extensions (use moz).
     11 |    const ORIG_P = [
             ^ 'const' is available in ES6 (use 'esversion: 6') or Mozilla JS extensions (use moz).
     19 |    const ORIG_S = [
             ^ 'const' is available in ES6 (use 'esversion: 6') or Mozilla JS extensions (use moz).
    284 |        let a = (x >> 24) & 0xFF;
                 ^ 'let' is available in ES6 (use 'esversion: 6') or Mozilla JS extensions (use moz).
    285 |        let b = (x >> 16) & 0xFF;
                 ^ 'let' is available in ES6 (use 'esversion: 6') or Mozilla JS extensions (use moz).
    286 |        let c = (x >> 8) & 0xFF;
                 ^ 'let' is available in ES6 (use 'esversion: 6') or Mozilla JS extensions (use moz).
    287 |        let d = x & 0xFF;
                 ^ 'let' is available in ES6 (use 'esversion: 6') or Mozilla JS extensions (use moz).
    289 |        let y = ctx.sbox[0][a] + ctx.sbox[1][b];
                 ^ 'let' is available in ES6 (use 'esversion: 6') or Mozilla JS extensions (use moz).
    297 |        let Xl = left;
                 ^ 'let' is available in ES6 (use 'esversion: 6') or Mozilla JS extensions (use moz).
    298 |        let Xr = right;
                 ^ 'let' is available in ES6 (use 'esversion: 6') or Mozilla JS extensions (use moz).
    299 |        let temp;
                 ^ 'let' is available in ES6 (use 'esversion: 6') or Mozilla JS extensions (use moz).
    301 |        for(let i = 0; i < N; ++i){
                     ^ 'let' is available in ES6 (use 'esversion: 6') or Mozilla JS extensions (use moz).
    321 |        let Xl = left;
                 ^ 'let' is available in ES6 (use 'esversion: 6') or Mozilla JS extensions (use moz).
    322 |        let Xr = right;
                 ^ 'let' is available in ES6 (use 'esversion: 6') or Mozilla JS extensions (use moz).
    323 |        let temp;
                 ^ 'let' is available in ES6 (use 'esversion: 6') or Mozilla JS extensions (use moz).
    325 |        for(let i = N + 1; i > 1; --i){
                     ^ 'let' is available in ES6 (use 'esversion: 6') or Mozilla JS extensions (use moz).
    357 |        for(let Row = 0; Row < 4; Row++)
                     ^ 'let' is available in ES6 (use 'esversion: 6') or Mozilla JS extensions (use moz).
    360 |            for(let Col = 0; Col < 256; Col++)
                         ^ 'let' is available in ES6 (use 'esversion: 6') or Mozilla JS extensions (use moz).
    366 |        let keyIndex = 0;
                 ^ 'let' is available in ES6 (use 'esversion: 6') or Mozilla JS extensions (use moz).
    367 |        for(let index = 0; index < N + 2; index++)
                     ^ 'let' is available in ES6 (use 'esversion: 6') or Mozilla JS extensions (use moz).
    377 |        let Data1 = 0;
                 ^ 'let' is available in ES6 (use 'esversion: 6') or Mozilla JS extensions (use moz).
    378 |        let Data2 = 0;
                 ^ 'let' is available in ES6 (use 'esversion: 6') or Mozilla JS extensions (use moz).
    379 |        let res = 0;
                 ^ 'let' is available in ES6 (use 'esversion: 6') or Mozilla JS extensions (use moz).
    380 |        for(let i = 0; i < N + 2; i += 2)
                     ^ 'let' is available in ES6 (use 'esversion: 6') or Mozilla JS extensions (use moz).
    389 |        for(let i = 0; i < 4; i++)
                     ^ 'let' is available in ES6 (use 'esversion: 6') or Mozilla JS extensions (use moz).
    391 |            for(let j = 0; j < 256; j += 2)
                         ^ 'let' is available in ES6 (use 'esversion: 6') or Mozilla JS extensions (use moz).
   src/cipher-core.js
    775 |            let key;
                     ^ 'let' is available in ES6 (use 'esversion: 6') or Mozilla JS extensions (use moz).
    784 |            const iv = WordArray.create(key.words.slice(keySize), ivSize * 4);
                     ^ 'const' is available in ES6 (use 'esversion: 6') or Mozilla JS extensions (use moz).

>> 28 errors in 43 files
Warning: Task "jshint:dev" failed. Use --force to continue.

Aborted due to warnings.
@liudonghua123 ➜ /workspaces/crypto-js (fix_jshint) $ 

@liudonghua123 ➜ /workspaces/crypto-js (fix_jshint) $ npm run test # need to add `"globals.self/globalThis": false` to .jshintrc

> crypto-js@4.2.0 test
> grunt default

Running "jsonlint:all" (jsonlint) task
>> 1 file lint free.

Running "jshint:dev" (jshint) task

   src/core.js
     16 |    if (typeof self !== 'undefined' && self.crypto) {
                                                ^ 'self' is not defined.
     17 |        crypto = self.crypto;
                          ^ 'self' is not defined.
     21 |    if (typeof globalThis !== 'undefined' && globalThis.crypto) {
                                                      ^ 'globalThis' is not defined.
     22 |        crypto = globalThis.crypto;
                          ^ 'globalThis' is not defined.

>> 4 errors in 43 files
Warning: Task "jshint:dev" failed. Use --force to continue.

Aborted due to warnings.
@liudonghua123 ➜ /workspaces/crypto-js (fix_jshint) $

@liudonghua123 ➜ /workspaces/crypto-js (fix_jshint) $ npm run test # need to update OpenSSLKdf.execute in cipher-core.js

> crypto-js@4.2.0 test
> grunt default

Running "jsonlint:all" (jsonlint) task
>> 1 file lint free.

Running "jshint:dev" (jshint) task

   src/cipher-core.js
    783 |            var iv = WordArray.create(key.words.slice(keySize), ivSize * 4);
                                               ^ 'key' used out of scope.
    784 |            key.sigBytes = keySize * 4;
                     ^ 'key' used out of scope.
    787 |            return CipherParams.create({ key: key, iv: iv, salt: salt });
                                                       ^ 'key' used out of scope.

>> 3 errors in 43 files
Warning: Task "jshint:dev" failed. Use --force to continue.

Aborted due to warnings.
@liudonghua123 ➜ /workspaces/crypto-js (fix_jshint) $
```