### PR TITLE
fix: make it tree-shakable

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,5 +58,6 @@
     "CBC",
     "Base64",
     "Base64url"
-  ]
+  ],
+  "sideEffects": false
 }


### PR DESCRIPTION
# description

when the content using `crypto-js` is not used, it should be tree-shaken. But it will still bundle about 200 KB sizes.

For example, if I import nothing except plain package name:

```typescript
import 'crypto-js'
```

It will bundle about 200 KB size content into output. So it need a `sideEffects` property to declare that it has no sideEffects and can be tree-shaken safely.