### PR TITLE
hotfix: error crypto with angular 19

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -36,7 +36,9 @@ var CryptoJS = CryptoJS || (function (Math, undefined) {
     if (!crypto && typeof require === 'function') {
         try {
             crypto = require('crypto');
-        } catch (err) {}
+        } catch (err) {
+            crypto = global.crypto;
+        }
     }
 
     /*


### PR DESCRIPTION
![imagen](https://github.com/user-attachments/assets/61ab071d-f423-43e1-ac46-937ded51d109)
Issue:

After updating Angular to version 19, I encountered the following error:

ts
Copiar código
TS2307: Cannot find module 'crypto' or its corresponding type declarations.
Solution:
To resolve this issue, I tried the following steps:

I set crypto to global.crypto, which worked fine in the browser and allowed the code to run without errors related to crypto.

ts
Copiar código
crypto = global.crypto;
Later, when I switched back to using require('crypto'), everything worked perfectly. This solution works well because, in a Node.js environment, require('crypto') functions as expected, but in the browser, global.crypto or alternative solutions like CryptoJS or Web Crypto API need to be used.

Summary:
By following this approach, I was able to resolve the error effectively: I first set crypto to global.crypto, and then used require('crypto') when I needed specific Node.js functionality. This allowed me to work with Angular 19 without any issues.